### PR TITLE
removes conda pin version with conda-build-all 1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,43 +23,36 @@ env:
         - NUMPY_BUILD_RESTRICTION="numpy >=1.11*"
         # The value below needs to be set but will be ignored.
         - CONDA_NPY="1.11"
-        - CONDA_VERSION=4.2*
+        - CONDA_VERSION=4.3*
 
 # Matrix is fully specified (for now) by os versions
 
 install:
     # Install and set up miniconda.
-    - if [ $TRAVIS_OS_NAME == "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; fi
-    - if [ $TRAVIS_OS_NAME == "osx" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+    - if [ $TRAVIS_OS_NAME == "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+    - if [ $TRAVIS_OS_NAME == "osx" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
     - bash miniconda.sh -b -p $CONDA_INSTALL_LOCN
     - export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
     - conda config --set always_yes true
 
-    - PIN_FILE_CONDA=${CONDA_INSTALL_LOCN}/conda-meta/pinned
-    - echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
-
+    # update to latest conda always
     - conda update --quiet conda
+
+    # set the ordering of additional channels
+    - conda config --prepend channels defaults
+    - conda config --append channels bccp
+    - conda config --append channels astropy
+    - conda config --append channels conda-forge # for conda-build-all (will be moved to defaults soon)
 
     # Install a couple of dependencies we need for sure.
     - conda install --quiet --yes astropy anaconda-client jinja2 cython pycrypto
     - conda install ruamel_yaml
 
-    # needed for mac and classylss
-    - conda install gcc
-
+    # latest conda build
     - conda install conda-build
 
     # Install conda-build-all
-    - conda install -c conda-forge conda-build-all=1.0.2
-
-    # so we can grab compiled packages for dependencies
-    - conda config --add channels bccp
-
-    # so we can grab compiled packages for dependencies
-    - conda config --add channels astropy
-
-    # conda build all is incompatible with anaconda-client 1.6.3
-    - conda install anaconda-client=1.6.2
+    - conda install "conda-build-all>=1.0.4"
 
     # To ease debugging, list installed packages
     - conda info -a


### PR DESCRIPTION
It looks like version 1.0.4 fixes the issues we were seeing previously with conda-build-all and conda 4.3*. For now, 1.0.4 is only on conda-forge but it looks like they are moving it to the defaults channel as well