### PR TITLE
lower conda-build version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
     - conda install ruamel_yaml
 
     # latest conda build
-    - conda install conda-build
+    - conda install "conda-build<3.0"
 
     # Install conda-build-all
     - conda install "conda-build-all>=1.0.4"


### PR DESCRIPTION
3.0.3 seems to break conda-build-all still, with a CONDA_NPY not found error.