### PR TITLE
Add python 3.8 to the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ sudo: true
 
 env:
     matrix:
+        - PYTHON_VERSION=3.8
         - PYTHON_VERSION=3.7
         - PYTHON_VERSION=3.6
 

--- a/recipe-templates/halotools/meta.yaml
+++ b/recipe-templates/halotools/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - requests
 
 test:
+  requires:
+    - pytest-astropy
   # Python imports
   imports:
     - halotools

--- a/recipe-templates/nbodykit/meta.yaml
+++ b/recipe-templates/nbodykit/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - fitsio
     - classylss >=0.2
     - mcfit
-    - sympy
+    - sympy !=1.6.0, !=1.6.1
     - numexpr
     - corrfunc
 

--- a/variants/cori/python-3.8.yaml
+++ b/variants/cori/python-3.8.yaml
@@ -1,0 +1,24 @@
+numpy:
+  - 1.16 # [unix]
+
+python:
+  - 3.8
+
+crayhost:
+  - cori
+
+mpi:
+  - cori.prgenv.gnu.mpi
+
+c_compiler :
+  - cori.prgenv.gnu
+cxx_compiler :
+  - cori.prgenv.gnu
+fortran_compiler :
+  - cori.prgenv.gnu
+
+pin_run_as_build:
+    cori.prgenv.gnu.mpi:
+      max_pin: x.x.x
+    cori.prgenv.gnu_linux64:
+      max_pin: x.x.x

--- a/variants/pc/python-3.8.yaml
+++ b/variants/pc/python-3.8.yaml
@@ -1,0 +1,19 @@
+numpy:
+  - 1.16 # [unix]
+
+python:
+  - 3.8
+
+mpi:
+#  - openmpi #   [osx]
+  - mpich
+#  - mpich2  #   [linux]
+
+pin_run_as_build:
+    openmpi:
+      max_pin: x.x
+    mpich:
+      max_pin: x.x
+    mpich2:
+      max_pin: x.x
+


### PR DESCRIPTION
Notice that the NERSC build scripts are not updated yet.